### PR TITLE
Add Logger middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,7 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-
-matrix:
-  include:
-    - { php: 5.4, env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' }
+  - '7.1'
 
 before_script:
   # Install librabbitmq-c

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.1.0",
         "psr/log": "~1.0",
         "symfony/options-resolver": "~2.6|~3.0"
     },

--- a/src/Consumer/Consumer.php
+++ b/src/Consumer/Consumer.php
@@ -2,12 +2,11 @@
 
 namespace Radish\Consumer;
 
+use Psr\Log\LoggerInterface;
 use Radish\Broker\Message;
 use Radish\Broker\QueueCollection;
 use Radish\Middleware\InitializableInterface;
-use Radish\Middleware\MiddlewareInterface;
 use Radish\Middleware\Next;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Consumer implements ConsumerInterface
@@ -42,15 +41,6 @@ class Consumer implements ConsumerInterface
 
     public function process(Message $message)
     {
-        if ($this->logger) {
-            $this->logger->debug('Processing message', [
-                'body' => $message->getBody(),
-                'headers' => $message->getHeaders(),
-                'exchange_name' => $message->getExchangeName(),
-                'routing_key' => $message->getRoutingKey()
-            ]);
-        }
-
         // Determine the queue from the message routing key (expects direct exchange)
         $queue = $this->queues->get($message->getRoutingKey());
 

--- a/src/Middleware/Logger/LoggerMiddleware.php
+++ b/src/Middleware/Logger/LoggerMiddleware.php
@@ -74,6 +74,6 @@ class LoggerMiddleware implements ConfigurableInterface, MiddlewareInterface
             'routing_key' => $message->getRoutingKey()
         ]);
 
-        $next($message, $queue);
+        return $next($message, $queue);
     }
 }

--- a/src/Middleware/Logger/LoggerMiddleware.php
+++ b/src/Middleware/Logger/LoggerMiddleware.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Radish\Middleware\Logger;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Radish\Broker\Message;
+use Radish\Broker\Queue;
+use Radish\Middleware\ConfigurableInterface;
+use Radish\Middleware\MiddlewareInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Logs details about the Radish message currently being processed.
+ */
+class LoggerMiddleware implements ConfigurableInterface, MiddlewareInterface
+{
+    const DEFAULT_LOG_LEVEL = LogLevel::DEBUG;
+    const DEFAULT_LOG_MESSAGE = 'Processing message';
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+    /**
+     * @var string
+     */
+    private $logLevel;
+    /**
+     * @var string
+     */
+    private $logMessage;
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'log_message' => self::DEFAULT_LOG_MESSAGE,
+            'log_level' => self::DEFAULT_LOG_LEVEL
+        ]);
+
+        $resolver->setAllowedTypes('log_message', 'string');
+        $resolver->setAllowedTypes('log_level', 'string');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOptions(array $options)
+    {
+        $this->logLevel = $options['log_level'];
+        $this->logMessage = $options['log_message'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __invoke(Message $message, Queue $queue, callable $next)
+    {
+        $this->logger->log($this->logLevel, $this->logMessage, [
+            'body' => $message->getBody(),
+            'exchange_name' => $message->getExchangeName(),
+            'headers' => $message->getHeaders(),
+            'routing_key' => $message->getRoutingKey()
+        ]);
+
+        $next($message, $queue);
+    }
+}

--- a/tests/Middleware/Logger/LoggerMiddlewareTest.php
+++ b/tests/Middleware/Logger/LoggerMiddlewareTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Radish\Middleware\Logger;
+
+use Mockery;
+use Mockery\Mock;
+use PHPUnit_Framework_TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Radish\Broker\Message;
+use Radish\Broker\Queue;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class LoggerMiddlewareTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Mock|LoggerInterface
+     */
+    private $logger;
+    /**
+     * @var Mock|Message
+     */
+    private $message;
+    /**
+     * @var LoggerMiddleware
+     */
+    private $middleware;
+    /**
+     * @var OptionsResolver
+     */
+    private $optionsResolver;
+    /**
+     * @var Mock|Queue
+     */
+    private $queue;
+
+    public function setUp()
+    {
+        $this->logger = Mockery::mock('Psr\Log\LoggerInterface', [
+            'log' => null,
+        ]);
+        $this->message = Mockery::mock('Radish\Broker\Message', [
+            'getBody' => 'my message content',
+            'getExchangeName' => 'my_exchange',
+            'getHeaders' => ['x-header-one' => '1', 'x-header-two' => '2'],
+            'getRoutingKey' => 'my.routing.key',
+        ]);
+        $this->optionsResolver = new OptionsResolver();
+        $this->queue = Mockery::mock('Radish\Broker\Queue', [
+            'getName' => 'test',
+            'ack' => null,
+            'nack' => null,
+        ]);
+
+        $this->middleware = new LoggerMiddleware($this->logger);
+    }
+
+    public function testInvokeWithDefaultOptionsLogsCorrectly()
+    {
+        $next = function () {
+            return true;
+        };
+        $this->middleware->configureOptions($this->optionsResolver);
+        $this->middleware->setOptions($this->optionsResolver->resolve());
+
+        $this->logger->shouldReceive('log')
+            ->with(LoggerMiddleware::DEFAULT_LOG_LEVEL, LoggerMiddleware::DEFAULT_LOG_MESSAGE, [
+                'body' => 'my message content',
+                'exchange_name' => 'my_exchange',
+                'headers' => ['x-header-one' => '1', 'x-header-two' => '2'],
+                'routing_key' => 'my.routing.key'
+            ])
+            ->once();
+
+        $this->middleware->__invoke($this->message, $this->queue, $next);
+    }
+
+    public function testInvokeWithCustomOptionsLogsCorrectly()
+    {
+        $next = function () {
+            return true;
+        };
+        $this->middleware->configureOptions($this->optionsResolver);
+        $this->middleware->setOptions($this->optionsResolver->resolve([
+            'log_level' => LogLevel::CRITICAL,
+            'log_message' => 'Doing a thing'
+        ]));
+
+        $this->logger->shouldReceive('log')
+            ->with(LogLevel::CRITICAL, 'Doing a thing', [
+                'body' => 'my message content',
+                'exchange_name' => 'my_exchange',
+                'headers' => ['x-header-one' => '1', 'x-header-two' => '2'],
+                'routing_key' => 'my.routing.key'
+            ])
+            ->once();
+
+        $this->middleware->__invoke($this->message, $this->queue, $next);
+    }
+
+    public function testInvokePassesCorrectArgsToNext()
+    {
+        $this->logger->shouldReceive('log');
+
+        $next = function ($message, $queue) {
+            self::assertSame($this->message, $message);
+            self::assertSame($this->queue, $queue);
+        };
+
+        $this->middleware->__invoke($this->message, $this->queue, $next);
+    }
+
+    public function testInvokeCallsTheMiddlewareAfterLogging()
+    {
+        $trace = [];
+        $next = function () use (&$trace) {
+            $trace[] = 'next()';
+        };
+        $this->logger->shouldReceive('log')
+            ->andReturnUsing(function () use (&$trace) {
+                $trace[] = 'log()';
+            });
+
+        $this->middleware->__invoke($this->message, $this->queue, $next);
+
+        self::assertEquals(['log()', 'next()'], $trace);
+    }
+}

--- a/tests/Middleware/Logger/LoggerMiddlewareTest.php
+++ b/tests/Middleware/Logger/LoggerMiddlewareTest.php
@@ -125,4 +125,28 @@ class LoggerMiddlewareTest extends PHPUnit_Framework_TestCase
 
         self::assertEquals(['log()', 'next()'], $trace);
     }
+
+    /**
+     * @dataProvider booleanProvider
+     * @param bool $boolean
+     */
+    public function testInvokeReturnsTheResultFromNextMiddleware($boolean)
+    {
+        $next = function () use ($boolean) {
+            return $boolean;
+        };
+
+        self::assertSame($boolean, $this->middleware->__invoke($this->message, $this->queue, $next));
+    }
+
+    /**
+     * @return array
+     */
+    public function booleanProvider()
+    {
+        return [
+            [true],
+            [false]
+        ];
+    }
 }


### PR DESCRIPTION
Moves the hardcoded "Processing message" log entry out to a middleware. This allows any processing that may need to occur using the Radish message to happen before the initial log is made.

See also https://github.com/jadu/RadishBundle/pull/3