### PR TITLE
Remove remaining hydrators from EventManager

### DIFF
--- a/src/Middleware/Doctrine/ObjectManagerMiddleware.php
+++ b/src/Middleware/Doctrine/ObjectManagerMiddleware.php
@@ -3,6 +3,9 @@
 namespace Radish\Middleware\Doctrine;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Psr\Log\LoggerInterface;
 use Radish\Broker\Message;
 use Radish\Broker\Queue;
@@ -37,25 +40,45 @@ class ObjectManagerMiddleware implements MiddlewareInterface
      */
     public function __invoke(Message $message, Queue $queue, callable $next)
     {
-        $return = $next($message, $queue);
+        try {
+            return $next($message, $queue);
+        } finally {
+            foreach ($this->managerRegistry->getManagers() as $managerName => $manager) {
+                if (!$manager->isOpen()) {
+                    $this->logger->info(
+                        sprintf('Resetting closed ObjectManager "%s"', $managerName),
+                        [
+                            'object_manager_name' => $managerName,
+                            'object_manager_class' => get_class($manager),
+                            'routing_key' => $message->getRoutingKey(),
+                            'queue' => $queue->getName()
+                        ]
+                    );
+                    $this->managerRegistry->resetManager($managerName);
+                } else {
+                    $manager->clear();
 
-        foreach ($this->managerRegistry->getManagers() as $managerName => $manager) {
-            if (!$manager->isOpen()) {
-                $this->logger->info(
-                    sprintf('Resetting closed ObjectManager "%s"', $managerName),
-                    [
-                        'object_manager_name' => $managerName,
-                        'object_manager_class' => get_class($manager),
-                        'routing_key' => $message->getRoutingKey(),
-                        'queue' => $queue->getName()
-                    ]
-                );
-                $this->managerRegistry->resetManager($managerName);
-            } else {
-                $manager->clear();
+                    if ($manager instanceof EntityManagerInterface) {
+                        $eventManager = $manager->getEventManager();
+
+                        /*
+                         * Any hydrators for incomplete Doctrine Statements (like via PDO),
+                         * eg. IterableResults, will keep a reference to the PDOStatement
+                         * which has an internal reference to the PDOConnection. The hydrator
+                         * is added as a listener to Doctrine's EventManager, which exists
+                         * for the lifetime of the consumer process. The connection will be held open
+                         * until there are no more references to it (whether direct or via PDOStatement),
+                         * thereby keeping the database connection open until the consumer exits,
+                         * therefore we need to remove all remaining hydrators from the EventManager.
+                         */
+                        foreach ($eventManager->getListeners(Events::onClear) as $listener) {
+                            if ($listener instanceof AbstractHydrator) {
+                                $eventManager->removeEventListener(Events::onClear, $listener);
+                            }
+                        }
+                    }
+                }
             }
         }
-
-        return $return;
     }
 }


### PR DESCRIPTION
We need to remove all hydrators of incomplete doctrine statements from the EventManager, because they are keeping the database connection open until the consumer exits, by referencing the PDOConnection